### PR TITLE
Correjimos los subtotales erroneos en primer carga del carrito

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -22,7 +22,7 @@ const convertToHtmlElem = (p) => {
               <td class="text-center">${p.name}</td>
               <td class="text-center">${p.currency} ${p.unitCost}</td>
               <td class="text-center"><input type="number" class="inputCantidad" value="${p.count}" onchange="updateSubtotal(this, ${p.unitCost}, '${p.currency}')"></td>
-              <td class="text-center" style="font-weight: bold;"> ${p.currency} <span class="subtotal">${p.unitCost}</span></td>
+              <td class="text-center" style="font-weight: bold;"> ${p.currency} <span class="subtotal">${p.unitCost * p.count}</span></td>
             </tr>`;
   };
 


### PR DESCRIPTION
Cambiamos la funcion que genera el HTML de cada elemento del carrito para que en el subtotal indique el precio unitario muliplicado por la cantidad de unidades agregadas